### PR TITLE
Fix bug where only initial sequence checked in aaCheck

### DIFF
--- a/R/aaCheck.R
+++ b/R/aaCheck.R
@@ -7,7 +7,7 @@ aaCheck <- function(seq){
     seq <- lapply(seq,toupper)
   }
   check <- unlist(lapply(seq,function(sequence){
-    !all(seq[[1]]%in%c("A" ,"C" ,"D" ,"E" ,"F" ,"G" ,"H" ,"I" ,"K" ,"L" ,"M" ,"N" ,"P" ,"Q" ,"R" ,"S" ,"T" ,"V" ,"W" ,"Y", "-"))
+    !all(sequence%in%c("A" ,"C" ,"D" ,"E" ,"F" ,"G" ,"H" ,"I" ,"K" ,"L" ,"M" ,"N" ,"P" ,"Q" ,"R" ,"S" ,"T" ,"V" ,"W" ,"Y", "-"))
   }))
   if(sum(check) > 0){
     sapply(which(check == TRUE),function(sequence){warning(paste0("Sequence ",sequence," has unrecognized amino acid types. Output value might be wrong calculated"),call. = FALSE)})

--- a/tests/testthat/test.aacheck.R
+++ b/tests/testthat/test.aacheck.R
@@ -1,5 +1,10 @@
 # NON STANDARD AMINO ACIDS PRESENT
+context("Check if amino acids are valid")
 
 test_that("Non standard aminoacids present in sequence",{expect_warning(
   aaCheck("KLRSTZMZ")
+)})
+
+test_that("Warning produced when non-standard amino acids present in any sequence except the first",{expect_warning(
+  aaCheck(c("KLR", "KLRSTZMZ"))
 )})


### PR DESCRIPTION
In the function `aaCheck`, if more than one sequence is checked, warnings are not produced for non-initial sequences. I added a test as well. 