### PR TITLE
fix bug of failing to read non-white spacing leading lines

### DIFF
--- a/R/readXVG.R
+++ b/R/readXVG.R
@@ -49,7 +49,7 @@ readXVG <- function(file) {
   title <- unquote(perlgsub("^@ \\s+title ", header))
 
   # Extracting the data
-  content <- perlgsub('^\\s+', content)
+  content <- perlgsub('^(?![@#])', content)
   content <- as.data.frame(
     t(sapply(
       content, 


### PR DESCRIPTION
the old code fails to read lines without white space in the beginning of data lines, e.g. when the time unit is picosecond:

50000.00000 123.00000
50010.00000 123.00000
50020.00000 123.00000