### PR TITLE
remove leading white spaces in data lines

### DIFF
--- a/R/readXVG.R
+++ b/R/readXVG.R
@@ -53,7 +53,7 @@ readXVG <- function(file) {
   content <- as.data.frame(
     t(sapply(
       content, 
-      (function(x) {unlist(strsplit(x, "\\s+"))}), 
+      (function(x) {unlist(strsplit(trimws(x, "b"), "\\s+"))}), 
       USE.NAMES = FALSE)
       ), stringsAsFactors = FALSE)
 


### PR DESCRIPTION
after last fix, if there are white spaces in the beginning of data lines, it will lead to a empty element in the data frame. This is error-prone, especially if not every data line has white spaces in the beginning. Now remove white spaces around each data line.