### PR TITLE
Add 'aaSequence' to get all amino acids uppercase single-char names, fix #29

### DIFF
--- a/R/aaSequence.R
+++ b/R/aaSequence.R
@@ -1,0 +1,8 @@
+#' Obtain all amino acids, as uppercase single-characters,
+#' for example, 'A' denotes alanine.
+#' @export
+aaSequence <- function() {
+  c("A" ,"C" ,"D" ,"E" ,"F" ,"G" ,"H" ,"I" ,"K" ,"L" ,
+    "M" ,"N" ,"P" ,"Q" ,"R" ,"S" ,"T" ,"V" ,"W" ,"Y"
+  )
+}

--- a/tests/testthat/test.aaSequence.R
+++ b/tests/testthat/test.aaSequence.R
@@ -1,0 +1,10 @@
+test_that("all amino acids are uppercase letters", {
+  amino_acids <- aaSequence()
+  expect_true(all(amino_acids %in% LETTERS))
+})
+
+test_that("Combining all amino acids is a valid peptide", {
+  polypeptide <- paste0(aaSequence(), collapse = "")
+  expect_silent(aaCheck(polypeptide))
+})
+


### PR DESCRIPTION
Hi @dosorio,

As promised, I've added `aaSequence`, both function and tests.

Sadly, I could not test, as I could not build the package. Because there is no CI on your repo either, you will have to check manually yourself. I am experience adding Travis CI to repos, but I am unsure if you'd be open for that.

Cheers, Richel