### PR TITLE
Integration of labelling at C- and N-terminus

### DIFF
--- a/R/massShift.R
+++ b/R/massShift.R
@@ -4,7 +4,9 @@
 #' @param seq An amino-acids sequence, in one letter code.
 #' @param monoisotopic A logical value \code{'TRUE'} or \code{'FALSE'} indicating if monoisotopic weights of amino-acids should be used
 #' @param label Set a predefined heavy isotope label. Accepts "none", "silac_13c", "silac_13c15n" and "15n". Overwrites input in \code{aaShift}.
-#' @param aaShift Define the mass difference in Dalton of given amino acids as a named vector. Use the amino acid one letter code as names and the mass shift in Dalton as values. 
+#' @param aaShift Define the mass difference in Dalton of given amino acids as a named vector. 
+#' Use the amino acid one letter code as names and the mass shift in Dalton as values. 
+#' N-terminal and C-terminal modifications can be defined by using "Nterm =" and "Cterm =", respectively.
 #' @source  For the predefined heavy isotope labels, compare:
 #' \itemize{
 #'  \item{silac_13c}{
@@ -37,6 +39,10 @@ function(seq, label = "none", aaShift = NULL, monoisotopic = TRUE){
   if(!is.null(aaShift) & is.null(names(aaShift))){
     stop("'aaShift' must be given as a named vector, e.g. 'aaShift = c(K = 6.020129)'.")
   }
+  allowed <- c(aaList(), "Cterm", "Nterm")
+  if(!is.null(aaShift) & !all(names(aaShift) %in% allowed)){
+    stop(paste("Unknown amino acids defined in 'aaShift'. Only the following names are allowed:", paste(allowed, collapse = ", ")))
+  }
   
   # Predefined labels
   if (label == "silac_13c"){
@@ -45,6 +51,8 @@ function(seq, label = "none", aaShift = NULL, monoisotopic = TRUE){
     aaShift <- c("K" = 8.014199 -0.071499*!monoisotopic, "R" = 10.008269-0.078669*!monoisotopic)
   } else if(label == "15n"){
     aaShift <- c(
+#      U = 1,
+#      O = 3,
       A = 1,
       R = 4,
       N = 2,
@@ -64,9 +72,7 @@ function(seq, label = "none", aaShift = NULL, monoisotopic = TRUE){
       T = 1,
       W = 2,
       Y = 1,
-      V = 1,
-      U = 1,
-      O = 3
+      V = 1
     ) * 0.997035 -0.003635*!monoisotopic # 0.997035 equals the mass shift from 14N to 15N. 0.9934 equals the average mass shift.
   }
   
@@ -76,6 +82,6 @@ function(seq, label = "none", aaShift = NULL, monoisotopic = TRUE){
   # Calculate mass shifts
   unlist(
     lapply(seq, function(x){
-      sum(aaShift[c(x)], na.rm = TRUE)
+      sum(aaShift[c(x)], aaShift["Nterm"], aaShift["Cterm"], na.rm = TRUE)
       }))
 }

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ Available functions
 |instaIndex	| Compute the instability index of a protein sequence |
 |kideraFactors | Compute the Kidera factors of a protein sequence |
 |lengthpep| Compute the aminoacid length of a protein sequence |
+|massShift | Compute the mass difference of a protein sequence labelled with stable isotope. |
 |membpos |	Compute theoretically the class of a protein sequence |
 |mswhimScores|Compute the MS-WHIM scores of a protein sequence|
 |mw	| Compute the molecular weight of a protein sequence |
+|mz | Compute the mass over charge (m/z) of a protein sequence |
 |pI	| Compute the isoelectic point (pI) of a protein sequence |
 |plotXVG	| Plot time series from GROMACS XVG files |
 |protFP|Compute the protFP descriptors of a protein sequence|

--- a/man/massShift.Rd
+++ b/man/massShift.Rd
@@ -29,7 +29,9 @@ massShift(seq, label = "none", aaShift = NULL, monoisotopic = TRUE)
 
 \item{label}{Set a predefined heavy isotope label. Accepts "none", "silac_13c", "silac_13c15n" and "15n". Overwrites input in \code{aaShift}.}
 
-\item{aaShift}{Define the mass difference in Dalton of given amino acids as a named vector. Use the amino acid one letter code as names and the mass shift in Dalton as values.}
+\item{aaShift}{Define the mass difference in Dalton of given amino acids as a named vector. 
+Use the amino acid one letter code as names and the mass shift in Dalton as values. 
+N-terminal and C-terminal modifications can be defined by using "Nterm =" and "Cterm =", respectively.}
 
 \item{monoisotopic}{A logical value \code{'TRUE'} or \code{'FALSE'} indicating if monoisotopic weights of amino-acids should be used}
 }


### PR DESCRIPTION
Hi!
Sorry for the second PR. I forgot to update the `Readme.md` to include the new functions. Also, I integrated a new feature in the `massShift` function: you can now also add labels at the N-terminus or C-terminus, independent of the amino acid sequence. 
Also, the input in `aaShift` is now tested and a specific error message is given, if the input cannot be matched to a standard amino acid.
Greetings, Florian